### PR TITLE
Various bug fixes.

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -238,13 +238,21 @@ bool sortOps(Operand* op1, Operand* op2){
 	else if (op2->getAccessMode() == REG_DIRECT){
 		return (((Register*) op1)->getBinEncoding() < ((Register*)op2)->getBinEncoding());
 	}
+	} else if (op1->getAccessMode() == IMMEDIATE) {
+		if (op2->getAccessMode() == REG_DIRECT) {
+			return false;
+		} else if (op2->getAccessMode() == IMMEDIATE) {
+			return (((Immediate*)op1)->getBinEncoding() < ((Immediate*)op2)->getBinEncoding());
+		}
 	}
+	return false;
 }
 
 
 std::vector<Operand*>* _helperOperandSort(vector<Operand*>* pList){
 
 	sort(pList->begin(), pList->end(), sortOps);
+	return pList;
 
 }
 

--- a/src/data_immediate.cpp
+++ b/src/data_immediate.cpp
@@ -82,7 +82,8 @@ switch(base)
 }
 
 	//clear out any zero-padding to make sure it fits in smallest byte count.
-	while (out.back() == 0 && (out.size() > 0))
+	//zero bytes isn't valid though...
+	while ((out.size() > 1) && out.back() == 0)
 		out.pop_back();
 
 	break;

--- a/src/data_immediate.cpp
+++ b/src/data_immediate.cpp
@@ -93,7 +93,7 @@ switch(base)
 	if (padding != 8)
 		in.insert(0, padding, (char)in[0]);
 	out.resize(in.length() / 8);
-	for (it = in.rbegin();it < in.rend();it++)
+	for (it = in.rbegin();it != in.rend();)
 	{
 	
 		for (int i = 0; i < 8;i++)

--- a/src/p86Assembler.cpp
+++ b/src/p86Assembler.cpp
@@ -948,9 +948,73 @@ int p86Assembler::_construct(auto_ptr<OpType> pPattern,OpNode* op, Operands& ops
 
             _addSeg(binseg);
             return 0;
-        }
-    }
+        } else if (imm[0]->getAccessMode() == IMMEDIATE_ADDR) {
+			// Ensure size matches up
 
+
+			modrm |= 0x06; //set to immediate address mode
+
+			// Since mod field is taken, three possibilites remain
+			// 1. reg field used for extended opcode -> second arg immediate
+			// 2. reg field used for register -> second arg register
+			// 3. only one argument
+
+			if (operandCount == 2) {
+				// There's a second argument
+
+				if ((pattern[0] & OP_MODRM_EXT) == 0) {
+					// The reg field is free, check if it's necessary
+					// Only direct reg access allowed, because there's a memory access in arg 0
+					if(reg[1] && ((pattern[arg1] & REG) == REG)) {
+						// arg1 is a register
+						// check that it's the right width
+						if (reg[1]->getAccessWidth() == (pattern[arg1] & AW_16BIT))
+							modrm |= reg[1]->getBinEncoding() << 3; // size is right
+						else
+							return 1; // Size is mismatched
+
+						binseg->push_back(pattern[opcodeIndex]);
+						binseg->push_back(modrm);
+						for (int i = 0; i < imm[0]->size(); i++)
+							binseg->push_back(imm[0]->getBinEncoding()[i]);
+						if (imm[0]->size() < 2)
+							binseg->push_back(0);
+						return 0;
+					}
+
+				} else if(imm[1] && ((pattern[arg1] & IMMEDIATE) == IMMEDIATE)) {
+					// arg1 is an immediate
+					if(((imm[1]->size() == 2) && ((pattern[arg1] & AW_16BIT) == AW_16BIT)) || ((imm[1]->size() == 1) && ((pattern[arg1] & AW_16BIT) == 0))) {
+						// size matches
+						binseg->push_back(pattern[opcodeIndex]);
+						binseg->push_back(modrm);
+						for (int i = 0; i < imm[0]->size(); i++)
+							binseg->push_back(imm[0]->getBinEncoding()[i]);
+						if (imm[0]->size() < 2)
+							binseg->push_back(0);
+
+						for (int i = 0; i < imm[1]->size(); i++)
+							binseg->push_back(imm[1]->getBinEncoding()[i]);
+						return 0;
+					} else {
+						// size mismatch
+						return 1;
+					}
+				}
+			} else {
+				// Only one argument
+				binseg->push_back(pattern[opcodeIndex]);
+				binseg->push_back(modrm);
+				for (int i = 0; i < imm[0]->size(); i++)
+					binseg->push_back(imm[0]->getBinEncoding()[i]);
+				if (imm[0]->size() < 2)
+					binseg->push_back(0);
+				return 0;
+
+			}
+
+		}
+	}
     return 1;
 }
 

--- a/src/p86Assembler.cpp
+++ b/src/p86Assembler.cpp
@@ -418,6 +418,9 @@ int p86Assembler::_construct(auto_ptr<OpType> pPattern,OpNode* op, Operands& ops
 
                 int len = (pattern[arg0] & 0x01 ) + 1;
 
+				for (int i = len; len > immediateData.size(); len--) {
+					binseg->push_back(0);
+				}
 
                 for (int i = 0; i < len; i++) {
                     binseg->push_back(immediateData[immediateData.size() - i - 1]);

--- a/src/p86asm.y
+++ b/src/p86asm.y
@@ -304,7 +304,7 @@
 
 	binary_type:BIN_PRE
 				{
-					Immediate *i = new Immediate($<pStr>1,BASE_BIN,IMMEDIATE);
+					Immediate *i = new Immediate($<pStr>1 + 2,BASE_BIN,IMMEDIATE);
 					free($<pStr>1);
 					Operands* ptr = new std::vector<Operand*>;
 					ptr->push_back(i);


### PR DESCRIPTION
**Bug fixes**
1. Problems with operand sorting in cases like [BP + SI + 0xIMM]
2. 0b was not truncated from binary literals
3. Some hex literals were truncated down to zero bytes
4. Processing binary literals caused crashes
5. Some immediates caused out-of-bounds errors when generating encoded instructions

**Added Features**
1. Added handling for first argument immediate addresses (Ex. ADC [0x1234], AX)
