### PR TITLE
Specified python2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ lasm: $(OBJ)
 
 
 p86asm.l: p86asm.l.inc opcodes.dat
-	python update-opcodes.py
+	python2 update-opcodes.py
 
 
 lex.yy.c :p86asm.l

--- a/src/update-opcodes.py
+++ b/src/update-opcodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 import sys,os 
 
 def run_parser(sFile):


### PR DESCRIPTION
Currently the build scripts assume `python` is python 2.  This is often not the case.  This version specifies `python2` so I works on all platforms.
